### PR TITLE
Use timeout at connection

### DIFF
--- a/socketcore/masterconnect.go
+++ b/socketcore/masterconnect.go
@@ -13,7 +13,7 @@ func masterConnectMethod(L *lua.LState) int {
 	hostname := L.ToString(2)
 	port := L.ToInt(3)
 
-	conn, err := net.Dial("tcp", fmt.Sprintf("%s:%d", hostname, port))
+	conn, err := net.DialTimeout("tcp", fmt.Sprintf("%s:%d", hostname, port), master.Timeout)
 	if err != nil {
 		L.Push(lua.LNil)
 		L.Push(lua.LString(err.Error()))


### PR DESCRIPTION
In old versions of luasocket, settimeout was only possible to set on a
client socket or a server socket, not the master socket. This was
changed in luasocket 2.0, which makes it possible to set settimeout on a
a master socket, hence have luasocket to have a timeout on the connect
call.

This wasn't implemented in gluasocket. It was possible to set a timeout
to the master socket, but it wasn't used for the connect call. Hence if
trying to connect to a server that is offline, the call will hang
forever.

This patch makes the connect call to honor the timeout set to the master
socket. This makes gluasocket work the same way as luasocket.